### PR TITLE
Allow for extra columns in the CSV that are not in the DB

### DIFF
--- a/src/Flynsarmy/CsvSeeder/CsvSeeder.php
+++ b/src/Flynsarmy/CsvSeeder/CsvSeeder.php
@@ -5,6 +5,7 @@ use Log;
 use DB;
 use Hash;
 use Illuminate\Database\Seeder;
+use Illuminate\Database\Schema;
 
 /**
  * Taken from http://laravelsnippets.com/snippets/seeding-database-with-csv-files-cleanly
@@ -206,8 +207,10 @@ class CsvSeeder extends Seeder
         $row_values = [];
 
         foreach ($mapping as $csvCol => $dbCol) {
-            if (!isset($row[$csvCol]) || $row[$csvCol] === '') {
-                $row_values[$dbCol] = NULL;
+            if (!isset($row[$csvCol]) || $row[$csvCol] === '' || !DB::getSchemaBuilder()->hasColumn($this->table, $dbCol)) {
+                if (DB::getSchemaBuilder()->hasColumn($this->table, $dbCol)) {
+                   $row_values[$dbCol] = NULL;
+                }
             }
             else {
                 $row_values[$dbCol] = $row[$csvCol];


### PR DESCRIPTION
My CSV seeder data files sometimes have extra columns, which caused errors during import.

I added code to cross reference the columns being imported to the database structure.
Extra input columns are now ignored and do not throw a SQL insert error.

This means that laravel-csv-seeder is now more robust:
* Column order is unimportant
* missing columns in the CSV that exist in the DB are inserted with NULL
* Extra columns in the CSV that do not exist in the DB are ignored (new functionality added by this pull request)
