### PR TITLE
Fixing issue: Invalid datetime format, causing by using MySQL in stri…

### DIFF
--- a/src/CsvSeeder.php
+++ b/src/CsvSeeder.php
@@ -71,8 +71,8 @@ class CsvSeeder extends Seeder
      * created_at and updated_at values to be added to each row. Only used if
      * $this->timestamps is true
      */
-    public string $created_at = '';
-    public string $updated_at = '';
+    public ?Carbon $created_at = null;
+    public ?Carbon $updated_at = null;
 
     /**
      * The mapping of CSV to DB column. If not specified manually, the first
@@ -98,10 +98,10 @@ class CsvSeeder extends Seeder
         // Cache created_at and updated_at if we need to
         if ($this->timestamps) {
             if (!$this->created_at) {
-                $this->created_at = Carbon::now()->toIso8601String();
+                $this->created_at = Carbon::now();
             }
             if (!$this->updated_at) {
-                $this->updated_at = Carbon::now()->toIso8601String();
+                $this->updated_at = Carbon::now();
             }
         }
 

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -190,7 +190,7 @@ class CsvTest extends \Orchestra\Testbench\TestCase
 
         // Test with timestamps
         $seeder->timestamps = true;
-        $seeder->created_at = \Carbon\Carbon::now()->toString();
+        $seeder->created_at = \Carbon\Carbon::now();
         $seeder->updated_at = $seeder->created_at;
         $actual = $seeder->readRow($row, $mapping);
         $expected = [


### PR DESCRIPTION
Faced with the issue with the use of MySQL with strict mode enabled.
During the import, the following error appears: `Invalid datetime format: 1292 Incorrect datetime value`

One of the possible fixes is changing `$created_at`, `$updated_at` type from string to the Cabon type, which will force Illuminate to do the black magic, with the date formatting.